### PR TITLE
Introduce MarkdownEditorInput widget

### DIFF
--- a/app/lib/presentation/settings/settings_page.dart
+++ b/app/lib/presentation/settings/settings_page.dart
@@ -13,6 +13,7 @@ import 'bloc/settings_bloc.dart';
 import 'bloc/settings_event.dart';
 import 'bloc/settings_state.dart';
 import '../../domain/entities/note_template.dart';
+import '../widgets/common/markdown_editor_input.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -521,24 +522,26 @@ class _SettingsPageState extends State<SettingsPage> {
       builder:
           (dialogContext) => AlertDialog(
             title: Text(template == null ? context.tr('settings.add_template') : context.tr('settings.edit_template')),
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                TextField(
-                  controller: nameController,
-                  decoration: InputDecoration(
-                    labelText: context.tr('settings.template_name'),
-                  ),
+            content: SizedBox(
+              width: double.maxFinite,
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      controller: nameController,
+                      decoration: InputDecoration(
+                        labelText: context.tr('settings.template_name'),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    MarkdownEditorInput(
+                      controller: contentController,
+                      label: context.tr('settings.template_content'),
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 16),
-                TextField(
-                  controller: contentController,
-                  decoration: InputDecoration(
-                    labelText: context.tr('settings.template_content'),
-                  ),
-                  maxLines: 5,
-                ),
-              ],
+              ),
             ),
             actions: [
               TextButton(

--- a/app/lib/presentation/widgets/common/markdown_editor_input.dart
+++ b/app/lib/presentation/widgets/common/markdown_editor_input.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+
+class MarkdownEditorInput extends StatefulWidget {
+  final TextEditingController controller;
+  final String? label;
+  final String? hint;
+
+  const MarkdownEditorInput({
+    super.key,
+    required this.controller,
+    this.label,
+    this.hint,
+  });
+
+  @override
+  State<MarkdownEditorInput> createState() => _MarkdownEditorInputState();
+}
+
+class _MarkdownEditorInputState extends State<MarkdownEditorInput> {
+  bool _isPreview = false;
+
+  void _insertText(String text, {int selectionOffset = 0}) {
+    final selection = widget.controller.selection;
+    if (selection.start < 0) {
+       // If no selection, append to end
+       final newText = widget.controller.text + text;
+       widget.controller.value = TextEditingValue(
+         text: newText,
+         selection: TextSelection.collapsed(offset: newText.length + selectionOffset),
+       );
+       return;
+    }
+    
+    final newText = widget.controller.text.replaceRange(
+      selection.start,
+      selection.end,
+      text,
+    );
+    final newSelectionIndex = selection.start + text.length + selectionOffset;
+
+    widget.controller.value = TextEditingValue(
+      text: newText,
+      selection: TextSelection.collapsed(offset: newSelectionIndex),
+    );
+  }
+
+  void _wrapSelection(String left, String right) {
+    final selection = widget.controller.selection;
+    if (selection.start < 0) {
+       _insertText('$left$right', selectionOffset: -right.length);
+       return;
+    }
+
+    final selectedText = widget.controller.text.substring(selection.start, selection.end);
+    final newText = '$left$selectedText$right';
+
+    widget.controller.value = widget.controller.value.replaced(
+      selection,
+      newText,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.label != null) ...[
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(widget.label!, style: Theme.of(context).textTheme.titleSmall),
+              // Preview Toggle
+              IconButton(
+                icon: Icon(_isPreview ? Icons.edit : Icons.visibility),
+                tooltip: _isPreview ? 'Edit' : 'Preview',
+                onPressed: () => setState(() => _isPreview = !_isPreview),
+                visualDensity: VisualDensity.compact,
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+        ] else ...[
+           // If no label, putting the toggle in the toolbar or above might be better.
+           // Let's add a small header row if label is null but we want the toggle.
+           Row(
+             mainAxisAlignment: MainAxisAlignment.end,
+             children: [
+                IconButton(
+                  icon: Icon(_isPreview ? Icons.edit : Icons.visibility),
+                  tooltip: _isPreview ? 'Edit' : 'Preview',
+                  onPressed: () => setState(() => _isPreview = !_isPreview),
+                  visualDensity: VisualDensity.compact,
+                ),
+             ],
+           ),
+        ],
+        
+        Container(
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceContainerHighest.withAlpha(50),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Toolbar (only visible in Edit mode)
+              if (!_isPreview)
+                Container(
+                  decoration: BoxDecoration(
+                    color: colorScheme.surfaceContainerHighest.withAlpha(100),
+                    border: Border(bottom: BorderSide(color: colorScheme.outlineVariant)),
+                  ),
+                  height: 48,
+                  child: ListView(
+                    scrollDirection: Axis.horizontal,
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    children: [
+                      _ToolbarButton(
+                        icon: Icons.format_bold,
+                        tooltip: 'Bold',
+                        onPressed: () => _wrapSelection('**', '**'),
+                      ),
+                      _ToolbarButton(
+                        icon: Icons.format_italic,
+                        tooltip: 'Italic',
+                        onPressed: () => _wrapSelection('*', '*'),
+                      ),
+                      _ToolbarButton(
+                        icon: Icons.strikethrough_s,
+                        tooltip: 'Strikethrough',
+                        onPressed: () => _wrapSelection('~~', '~~'),
+                      ),
+                      const VerticalDivider(indent: 8, endIndent: 8, width: 16),
+                      _ToolbarButton(
+                        icon: Icons.list,
+                        tooltip: 'Bullet List',
+                        onPressed: () => _insertText('\n- '),
+                      ),
+                      _ToolbarButton(
+                        icon: Icons.check_box_outlined,
+                        tooltip: 'Task List',
+                        onPressed: () => _insertText('\n- [ ] '),
+                      ),
+                      const VerticalDivider(indent: 8, endIndent: 8, width: 16),
+                      _ToolbarButton(
+                        icon: Icons.title,
+                        tooltip: 'Heading 1',
+                        onPressed: () => _insertText('\n# '),
+                      ),
+                      _ToolbarButton(
+                        icon: Icons.code,
+                        tooltip: 'Code',
+                        onPressed: () => _wrapSelection('`', '`'),
+                      ),
+                      _ToolbarButton(
+                        icon: Icons.data_object,
+                        tooltip: 'Code Block',
+                        onPressed: () => _wrapSelection('```\n', '\n```'),
+                      ),
+                    ],
+                  ),
+                ),
+                
+              // Editor / Preview Area
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 200),
+                child: _isPreview
+                    ? Container(
+                        width: double.infinity,
+                        constraints: const BoxConstraints(minHeight: 150),
+                        padding: const EdgeInsets.all(16),
+                        color: colorScheme.surface,
+                        alignment: Alignment.topLeft,
+                        child: MarkdownBody(
+                          data: widget.controller.text.isEmpty 
+                              ? '*${widget.hint ?? "No content"}*' 
+                              : widget.controller.text,
+                          styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
+                             blockquote: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                               color: colorScheme.onSurfaceVariant,
+                               fontStyle: FontStyle.italic,
+                             ),
+                          ),
+                        ),
+                      )
+                    : TextField(
+                        controller: widget.controller,
+                        maxLines: null,
+                        minLines: 5,
+                        keyboardType: TextInputType.multiline,
+                        decoration: InputDecoration(
+                          hintText: widget.hint,
+                          border: InputBorder.none,
+                          contentPadding: const EdgeInsets.all(16),
+                          filled: true,
+                          fillColor: colorScheme.surface,
+                        ),
+                      ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ToolbarButton extends StatelessWidget {
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onPressed;
+
+  const _ToolbarButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: Icon(icon, size: 20),
+      tooltip: tooltip,
+      onPressed: onPressed,
+      style: IconButton.styleFrom(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        padding: EdgeInsets.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      ),
+    );
+  }
+}

--- a/app/lib/presentation/widgets/focus/focus_notes.dart
+++ b/app/lib/presentation/widgets/focus/focus_notes.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart' hide TextDirection;
 import 'package:flutter/material.dart';
+import '../common/markdown_editor_input.dart';
 
 import 'package:focus_flow_app/domain/entities/note_template.dart';
 
@@ -139,40 +140,9 @@ class _FocusNotesWidgetState extends State<FocusNotesWidget> {
               ],
             ),
             const SizedBox(height: 16),
-            TextField(
+            MarkdownEditorInput(
               controller: _notesController,
-              maxLines: 8,
-              style: Theme.of(context).textTheme.bodyMedium,
-              decoration: InputDecoration(
-                hintText: context.tr('focus.notes_hint'),
-                hintStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: colorScheme.onSurfaceVariant.withAlpha(
-                    (255 * 0.5).round(),
-                  ),
-                ),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(16),
-                  borderSide: BorderSide.none,
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(16),
-                  borderSide: BorderSide(
-                    color: colorScheme.outlineVariant.withAlpha(
-                      (255 * 0.2).round(),
-                    ),
-                  ),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(16),
-                  borderSide: BorderSide(
-                    color: colorScheme.primary.withAlpha((255 * 0.5).round()),
-                    width: 2,
-                  ),
-                ),
-                filled: true,
-                fillColor: colorScheme.surface.withAlpha((255 * 0.5).round()),
-                contentPadding: const EdgeInsets.all(16),
-              ),
+              hint: context.tr('focus.notes_hint'),
             ),
           ],
         ),

--- a/app/lib/presentation/widgets/focus/manual_session_bottom_sheet.dart
+++ b/app/lib/presentation/widgets/focus/manual_session_bottom_sheet.dart
@@ -6,6 +6,7 @@ import 'package:focus_flow_app/domain/entities/task.dart';
 import 'package:focus_flow_app/presentation/focus/bloc/focus_bloc.dart';
 import 'package:focus_flow_app/presentation/focus/bloc/focus_event.dart';
 import 'package:focus_flow_app/presentation/focus/bloc/focus_state.dart';
+import '../common/markdown_editor_input.dart';
 
 class ManualSessionBottomSheet extends StatefulWidget {
   const ManualSessionBottomSheet({super.key});
@@ -223,13 +224,9 @@ class _ManualSessionBottomSheetState extends State<ManualSessionBottomSheet> {
                 const SizedBox(height: 16),
 
                 // Notes
-                TextField(
+                MarkdownEditorInput(
                   controller: _notesController,
-                  decoration: InputDecoration(
-                    labelText: 'manual_session.notes'.tr(),
-                    alignLabelWithHint: true,
-                  ),
-                  maxLines: 3,
+                  label: 'manual_session.notes'.tr(),
                 ),
                 const SizedBox(height: 24),
 

--- a/app/lib/presentation/widgets/focus/session_details_modal.dart
+++ b/app/lib/presentation/widgets/focus/session_details_modal.dart
@@ -1,5 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import '../common/markdown_editor_input.dart';
 import 'package:focus_flow_app/domain/entities/category.dart';
 import 'package:focus_flow_app/domain/entities/category_with_tasks.dart';
 import 'package:focus_flow_app/domain/entities/focus_session.dart';
@@ -254,9 +256,9 @@ class _SessionDetailsModalState extends State<SessionDetailsModal> {
                   borderRadius: BorderRadius.circular(12),
                   border: Border.all(color: colorScheme.outlineVariant),
                 ),
-                child: Text(
-                  widget.session.notes!,
-                  style: Theme.of(context).textTheme.bodyMedium,
+                child: MarkdownBody(
+                  data: widget.session.notes!,
+                  styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)),
                 ),
               ),
             ],
@@ -402,15 +404,9 @@ class _SessionDetailsModalState extends State<SessionDetailsModal> {
             ),
             const SizedBox(height: 24),
             
-            TextField(
+            MarkdownEditorInput(
               controller: _notesController,
-              decoration: InputDecoration(
-                labelText: context.tr('focus.notes_title'),
-                alignLabelWithHint: true,
-                border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
-                prefixIcon: const Icon(Icons.notes),
-              ),
-              maxLines: 3,
+              label: context.tr('focus.notes_title'),
             ),
           ],
           

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -371,6 +371,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.7+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -557,6 +565,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.0"
   matcher:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   package_info_plus: ^9.0.0
   shared_preferences: ^2.5.4
   web_socket_channel: ^3.0.3
+  flutter_markdown: ^0.7.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Refactors the input for multi-line text fields to use a new MarkdownEditorInput widget. This widget provides rich text editing features such as bold, italic, lists, and code blocks, along with a preview mode. This change improves the user experience for note-taking and template content editing.

Close #12 