### PR TITLE
fix: Focus list does not update after adding a new Category or Task

### DIFF
--- a/app/lib/presentation/focus/bloc/focus_event.dart
+++ b/app/lib/presentation/focus/bloc/focus_event.dart
@@ -43,6 +43,8 @@ class PomodoroStateUpdated extends FocusEvent {
 
 class ReloadTodaySessions extends FocusEvent {}
 
+class ReloadCategoriesAndTasks extends FocusEvent {}
+
 class WebSocketConnectionUpdated extends FocusEvent {
   final bool isConnected;
 

--- a/app/lib/presentation/focus/focus_view.dart
+++ b/app/lib/presentation/focus/focus_view.dart
@@ -34,6 +34,7 @@ class FocusViewState extends State<FocusView> with WidgetsBindingObserver {
     // Check initial state for active session color
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final state = context.read<FocusBloc>().state;
+      context.read<FocusBloc>().add(ReloadCategoriesAndTasks());
       if (state.selectedCategory != null) {
         try {
           int colorInt = int.parse(
@@ -58,6 +59,7 @@ class FocusViewState extends State<FocusView> with WidgetsBindingObserver {
     if (state == AppLifecycleState.resumed) {
       logger.d('App resumed, checking WebSocket connection');
       context.read<FocusBloc>().add(CheckConnection());
+      context.read<FocusBloc>().add(ReloadCategoriesAndTasks());
     }
   }
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -988,7 +988,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focus_flow_cloud"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "adapters",
  "application",


### PR DESCRIPTION
Introduce a new event to allow manual reloading of categories and tasks. This event will fetch both categories and orphan tasks and update the bloc state. This is triggered on app resume and during initial build to ensure data freshness.