### PR TITLE
fix: Template creation modal does not open

### DIFF
--- a/app/lib/presentation/settings/settings_page.dart
+++ b/app/lib/presentation/settings/settings_page.dart
@@ -29,181 +29,185 @@ class _SettingsPageState extends State<SettingsPage> {
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (context) => sl<SettingsBloc>()..add(LoadSettings()),
-      child: Scaffold(
-      appBar: AppBar(title: Text(context.tr('settings.title'))),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          Card(
-            child: Padding(
+      child: Builder(
+        builder: (context) {
+          return Scaffold(
+            appBar: AppBar(title: Text(context.tr('settings.title'))),
+            body: ListView(
               padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Icon(
-                        Icons.palette_outlined,
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                      const SizedBox(width: 12),
-                      Text(
-                        context.tr('settings.appearance'),
-                        style: Theme.of(context).textTheme.titleLarge,
-                      ),
-                    ],
+              children: [
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.palette_outlined,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                            const SizedBox(width: 12),
+                            Text(
+                              context.tr('settings.appearance'),
+                              style: Theme.of(context).textTheme.titleLarge,
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                        BlocBuilder<ThemeCubit, ThemeState>(
+                          builder: (context, state) {
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                SwitchListTile(
+                                  title: Text(context.tr('settings.dark_mode')),
+                                  subtitle: Text(
+                                    state.isDarkMode
+                                        ? context.tr('settings.switch_to_light')
+                                        : context.tr('settings.switch_to_dark'),
+                                  ),
+                                  value: state.isDarkMode,
+                                  onChanged:
+                                      state.isLoading
+                                          ? null
+                                          : (_) {
+                                            context.read<ThemeCubit>().toggleTheme();
+                                          },
+                                  secondary: Icon(
+                                    state.isDarkMode
+                                        ? Icons.dark_mode
+                                        : Icons.light_mode,
+                                    color: Theme.of(context).colorScheme.primary,
+                                  ),
+                                ),
+                                ListTile(
+                                  title: Text(context.tr('settings.language')),
+                                  subtitle: Text(
+                                    context.locale.languageCode == 'en'
+                                        ? context.tr('settings.english')
+                                        : context.tr('settings.italian'),
+                                  ),
+                                  leading: Icon(
+                                    Icons.language,
+                                    color: Theme.of(context).colorScheme.primary,
+                                  ),
+                                  onTap: () {
+                                    showDialog(
+                                      context: context,
+                                      builder:
+                                          (context) => SimpleDialog(
+                                            title: Text(
+                                              context.tr('settings.select_language'),
+                                            ),
+                                            children: [
+                                              SimpleDialogOption(
+                                                onPressed: () {
+                                                  const locale = Locale('en');
+                                                  context
+                                                      .read<LocaleCubit>()
+                                                      .setLocale(locale);
+                                                  Navigator.pop(context);
+                                                },
+                                                child: Text(
+                                                  context.tr('settings.english'),
+                                                ),
+                                              ),
+                                              SimpleDialogOption(
+                                                onPressed: () {
+                                                  const locale = Locale('it');
+                                                  context
+                                                      .read<LocaleCubit>()
+                                                      .setLocale(locale);
+                                                  Navigator.pop(context);
+                                                },
+                                                child: Text(
+                                                  context.tr('settings.italian'),
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                    );
+                                  },
+                                ),
+                              ],
+                            );
+                          },
+                        ),
+                      ],
+                    ),
                   ),
-                  const SizedBox(height: 16),
-                  BlocBuilder<ThemeCubit, ThemeState>(
-                    builder: (context, state) {
-                      return Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          SwitchListTile(
-                            title: Text(context.tr('settings.dark_mode')),
-                            subtitle: Text(
-                              state.isDarkMode
-                                  ? context.tr('settings.switch_to_light')
-                                  : context.tr('settings.switch_to_dark'),
-                            ),
-                            value: state.isDarkMode,
-                            onChanged:
-                                state.isLoading
-                                    ? null
-                                    : (_) {
-                                      context.read<ThemeCubit>().toggleTheme();
-                                    },
-                            secondary: Icon(
-                              state.isDarkMode
-                                  ? Icons.dark_mode
-                                  : Icons.light_mode,
+                ),
+                const SizedBox(height: 16),
+                _buildNoteTemplateSection(context),
+                const SizedBox(height: 16),
+                _buildAccountSection(context),
+                const SizedBox(height: 16),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.info_outline,
                               color: Theme.of(context).colorScheme.primary,
                             ),
-                          ),
-                          ListTile(
-                            title: Text(context.tr('settings.language')),
-                            subtitle: Text(
-                              context.locale.languageCode == 'en'
-                                  ? context.tr('settings.english')
-                                  : context.tr('settings.italian'),
+                            const SizedBox(width: 12),
+                            Text(
+                              context.tr('settings.about'),
+                              style: Theme.of(context).textTheme.titleLarge,
                             ),
-                            leading: Icon(
-                              Icons.language,
-                              color: Theme.of(context).colorScheme.primary,
-                            ),
-                            onTap: () {
-                              showDialog(
-                                context: context,
-                                builder:
-                                    (context) => SimpleDialog(
-                                      title: Text(
-                                        context.tr('settings.select_language'),
-                                      ),
-                                      children: [
-                                        SimpleDialogOption(
-                                          onPressed: () {
-                                            const locale = Locale('en');
-                                            context
-                                                .read<LocaleCubit>()
-                                                .setLocale(locale);
-                                            Navigator.pop(context);
-                                          },
-                                          child: Text(
-                                            context.tr('settings.english'),
-                                          ),
-                                        ),
-                                        SimpleDialogOption(
-                                          onPressed: () {
-                                            const locale = Locale('it');
-                                            context
-                                                .read<LocaleCubit>()
-                                                .setLocale(locale);
-                                            Navigator.pop(context);
-                                          },
-                                          child: Text(
-                                            context.tr('settings.italian'),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                              );
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                        FutureBuilder<String>(
+                          future: sl<GetAppVersion>()(),
+                          builder: (context, snapshot) {
+                            return ListTile(
+                              title: Text(context.tr('settings.version')),
+                              subtitle: Text(snapshot.data ?? '...'),
+                              leading: const Icon(Icons.code),
+                            );
+                          },
+                        ),
+                        ListTile(
+                          title: Text(context.tr('settings.app_name')),
+                          subtitle: Text(context.tr('settings.app_description')),
+                          leading: const Icon(Icons.timer),
+                        ),
+                        const Divider(),
+                        ListTile(
+                          title: const Text('Server Configuration'),
+                          subtitle: FutureBuilder<String?>(
+                            future: Future.value(sl<ConfigurationService>().apiBaseUrl),
+                            builder: (context, snapshot) {
+                              return Text(snapshot.data ?? 'Not Configured');
                             },
                           ),
-                        ],
-                      );
-                    },
-                  ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 16),
-          _buildNoteTemplateSection(context),
-          const SizedBox(height: 16),
-          _buildAccountSection(context),
-          const SizedBox(height: 16),
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Icon(
-                        Icons.info_outline,
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                      const SizedBox(width: 12),
-                      Text(
-                        context.tr('settings.about'),
-                        style: Theme.of(context).textTheme.titleLarge,
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 16),
-                  FutureBuilder<String>(
-                    future: sl<GetAppVersion>()(),
-                    builder: (context, snapshot) {
-                      return ListTile(
-                        title: Text(context.tr('settings.version')),
-                        subtitle: Text(snapshot.data ?? '...'),
-                        leading: const Icon(Icons.code),
-                      );
-                    },
-                  ),
-                  ListTile(
-                    title: Text(context.tr('settings.app_name')),
-                    subtitle: Text(context.tr('settings.app_description')),
-                    leading: const Icon(Icons.timer),
-                  ),
-                  const Divider(),
-                  ListTile(
-                    title: const Text('Server Configuration'),
-                    subtitle: FutureBuilder<String?>(
-                      future: Future.value(sl<ConfigurationService>().apiBaseUrl),
-                      builder: (context, snapshot) {
-                        return Text(snapshot.data ?? 'Not Configured');
-                      },
-                    ),
-                    leading: const Icon(Icons.cloud_sync),
-                    onTap: () {
-                      Navigator.push(
-                        context, 
-                        MaterialPageRoute(
-                          builder: (_) => BackendConfigPage(
-                            configService: sl<ConfigurationService>(),
-                          ),
+                          leading: const Icon(Icons.cloud_sync),
+                          onTap: () {
+                            Navigator.push(
+                              context, 
+                              MaterialPageRoute(
+                                builder: (_) => BackendConfigPage(
+                                  configService: sl<ConfigurationService>(),
+                                ),
+                              ),
+                            );
+                          },
                         ),
-                      );
-                    },
+                      ],
+                    ),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
-          ),
-        ],
-      ),
+          );
+        }
       ),
     );
   }


### PR DESCRIPTION
This change wraps the existing Scaffold in a Builder widget. This is done to correctly obtain the BuildContext needed for accessing cubits and blocs within the Scaffold's children, specifically for the `context.tr` calls and `Navigator.push`.