### PR TITLE
fix: App hangs indefinitely when refresh token is invalid

### DIFF
--- a/app/lib/adapters/network/auth_interceptor.dart
+++ b/app/lib/adapters/network/auth_interceptor.dart
@@ -35,7 +35,8 @@ class AuthInterceptor extends QueuedInterceptorsWrapper {
       if (err.response?.statusCode == 401) {
         final path = err.requestOptions.path;
         if (path.contains('/api/auth/login') ||
-            path.contains('/api/auth/refresh')) {
+            path.contains('/api/auth/refresh') ||
+            path.contains('/api/auth/logout')) {
           return super.onError(err, handler);
         }
 

--- a/app/lib/presentation/pages/onboarding/backend_config_page.dart
+++ b/app/lib/presentation/pages/onboarding/backend_config_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import '../../../core/services/configuration_service.dart';
 import '../../../main.dart'; // To access restartApp
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../auth/cubit/auth_cubit.dart';
 
 class BackendConfigPage extends StatefulWidget {
   final ConfigurationService configService;
@@ -48,6 +50,15 @@ class _BackendConfigPageState extends State<BackendConfigPage> {
       }
 
       await widget.configService.setApiBaseUrl(url);
+
+      // Force logout to clear tokens from the previous server
+      if (mounted) {
+        try {
+          await context.read<AuthCubit>().logout();
+        } catch (_) {
+          // Ignore if AuthCubit is not found (e.g. during first run/onboarding)
+        }
+      }
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
Exclude the logout endpoint from the 401 unauthorized bypass logic in the authentication interceptor. This ensures that a logout request itself won't trigger a refresh or further unexpected behavior if it returns a 401.

Additionally, this commit forces a logout within the `BackendConfigPage` after a new API URL is configured. This helps to clear any existing authentication tokens associated with the previous server configuration, preventing potential inconsistencies.