### PR TITLE
Refactor websocket handling for stale connections

### DIFF
--- a/app/lib/adapters/ws/ws_repository.dart
+++ b/app/lib/adapters/ws/ws_repository.dart
@@ -17,6 +17,14 @@ class WebsocketRepository {
   StreamSubscription? _subscription;
   bool _isConnected = false;
 
+  /// Timestamp of the last message received from the server.
+  /// Used to detect ghost (stale) connections after mobile standby.
+  DateTime? _lastMessageReceivedAt;
+
+  /// A connection is considered stale when [_isConnected] is true but no
+  /// message has been received for this duration.
+  static const _staleThreshold = Duration(seconds: 90);
+
   // Stream controllers for different message types
   final _serverResponseController =
       StreamController<ServerResponse>.broadcast();
@@ -48,6 +56,7 @@ class WebsocketRepository {
       }
 
       logger.d('Connecting to $wsUrl...');
+      _lastMessageReceivedAt = null;
       final token = _tokenService.getToken();
 
       // Pass token as query parameter instead of header to avoid server 500 errors
@@ -98,6 +107,7 @@ class WebsocketRepository {
 
   /// Handle incoming WebSocket messages
   void _handleMessage(dynamic data) {
+    _lastMessageReceivedAt = DateTime.now();
     try {
       logger.d('Received message: $data');
       final jsonData = json.decode(data as String) as Map<String, dynamic>;
@@ -284,21 +294,60 @@ class WebsocketRepository {
     return _isConnected;
   }
 
-  /// Disconnect from the WebSocket server
+  /// Returns true when the connection flag is set but no message has arrived
+  /// within [_staleThreshold]. This detects "ghost" connections that survive
+  /// OS-level TCP teardown during extended mobile standby.
+  bool isConnectionStale() {
+    if (!_isConnected) return false;
+    if (_lastMessageReceivedAt == null) return false;
+    return DateTime.now().difference(_lastMessageReceivedAt!) > _staleThreshold;
+  }
+
+  /// Tear down the current socket and open a fresh one.
+  /// Stream controllers are preserved so existing listeners keep working.
+  Future<void> forceReconnect() async {
+    logger.i('Forcing WebSocket reconnect...');
+    await disconnect();
+    await connect();
+  }
+
+  /// Disconnect from the WebSocket server.
+  /// Stream controllers are intentionally kept open so that a subsequent
+  /// [connect] or [forceReconnect] can continue delivering events to existing
+  /// listeners without them needing to re-subscribe.
   Future<void> disconnect() async {
+    _isConnected = false;
+    await _subscription?.cancel();
+    _subscription = null;
     if (_ws != null) {
-      await _subscription?.cancel();
-      await _ws!.sink.close();
+      try {
+        await _ws!.sink.close();
+      } catch (e) {
+        logger.w('Error closing WebSocket sink: $e');
+      }
       _ws = null;
-      _isConnected = false;
-      logger.i('Disconnected from websocket');
+    }
+    logger.i('Disconnected from websocket');
+    if (!_connectionStatusController.isClosed) {
       _connectionStatusController.add(false);
     }
+  }
 
-    // Close stream controllers
-    await _serverResponseController.close();
-    await _broadcastEventController.close();
-    await _pomodoroStateController.close();
-    await _connectionStatusController.close();
+  /// Permanently release all resources including stream controllers.
+  /// Call this only when the repository itself is being torn down (app exit).
+  Future<void> dispose() async {
+    await disconnect();
+    if (!_serverResponseController.isClosed) {
+      await _serverResponseController.close();
+    }
+    if (!_broadcastEventController.isClosed) {
+      await _broadcastEventController.close();
+    }
+    if (!_pomodoroStateController.isClosed) {
+      await _pomodoroStateController.close();
+    }
+    if (!_connectionStatusController.isClosed) {
+      await _connectionStatusController.close();
+    }
   }
 }

--- a/app/lib/presentation/focus/bloc/focus_bloc.dart
+++ b/app/lib/presentation/focus/bloc/focus_bloc.dart
@@ -444,12 +444,18 @@ class FocusBloc extends Bloc<FocusEvent, FocusState> {
     if (!_websocketRepository.isConnected()) {
       logger.d('WebSocket not connected, attempting to connect...');
       await _websocketRepository.connect();
+    } else if (_websocketRepository.isConnectionStale()) {
+      // The connection flag is set but no message has been received recently.
+      // This is a "ghost" connection left over from before mobile standby.
+      logger.w('WebSocket connection is stale after standby, forcing reconnect...');
+      await _websocketRepository.forceReconnect();
     } else {
-      logger.d('WebSocket already connected');
-      // Ensure state reflects reality
+      logger.d('WebSocket already connected and healthy');
+      // Ensure state reflects reality and get fresh data.
       if (!state.isWebSocketConnected) {
         emit(state.copyWith(isWebSocketConnected: true));
       }
+      _websocketRepository.requestSync();
     }
   }
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -989,7 +989,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focus_flow_cloud"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "adapters",
  "application",

--- a/backend/crates/adapters/src/http/ws/ws_handler.rs
+++ b/backend/crates/adapters/src/http/ws/ws_handler.rs
@@ -136,8 +136,12 @@ async fn handle_socket(ws: WebSocket, state: AppState, request_id: RequestId, us
                         debug!("Client requested close");
                         break;
                     }
-                    Ok(Message::Ping(_)) => {
-                        debug!("Received ping");
+                    Ok(Message::Ping(data)) => {
+                        debug!("Received ping, sending pong");
+                        if tx_clone.send(Message::Pong(data)).is_err() {
+                            debug!("Failed to send pong, client disconnected");
+                            break;
+                        }
                     }
                     Ok(Message::Pong(_)) => {
                         debug!("Received pong");


### PR DESCRIPTION
Introduce logic to detect and handle stale WebSocket connections that may occur after mobile standby.

Add `_lastMessageReceivedAt` timestamp and `isConnectionStale()` method to `WebsocketRepository`.
The `FocusBloc` now checks for stale connections and forces a reconnect if necessary.

Update backend to explicitly send pong responses for incoming pings. This ensures the connection remains active and prevents the client from incorrectly identifying it as stale.

Close #62 